### PR TITLE
Remove unnecessary XS-Testsuite field in debian/control.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+django-testscenarios (0.10-1~bpo9+2) UNRELEASED; urgency=medium
+
+  * Remove unnecessary XS-Testsuite field in debian/control.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 01:42:01 +0100
+
 django-testscenarios (0.10-1~bpo9+1) stretch-backports; urgency=medium
 
   * Rebuild for stretch-backports.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-django-testscenarios (0.10-1~bpo9+2) UNRELEASED; urgency=medium
-
-  * Remove unnecessary XS-Testsuite field in debian/control.
-
- -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 01:42:01 +0100
-
 django-testscenarios (0.10-1~bpo9+1) stretch-backports; urgency=medium
 
   * Rebuild for stretch-backports.

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 8.0.0), dh-python,
  python3-all,python3-setuptools, python3-django, python3-testtools,
  python3-mimeparse, python3-testscenarios, python3-django-testproject,
 X-Python-Version: >=2.7
-XS-Testsuite: autopkgtest
 Standards-Version: 4.0.0
 Homepage: http://www.linaro.org/engineering/validation
 Vcs-Git: https://github.com/Linaro/pkg-django-testscenarios.git


### PR DESCRIPTION
Remove unnecessary XS-Testsuite field in debian/control.

Fixes lintian: xs-testsuite-field-in-debian-control
See https://lintian.debian.org/tags/xs-testsuite-field-in-debian-control.html for more details.
